### PR TITLE
increase default max and min password lengths

### DIFF
--- a/config.go
+++ b/config.go
@@ -186,8 +186,8 @@ func (c *Config) Defaults() {
 		Rules{
 			FieldName:       "password",
 			Required:        true,
-			MinLength:       4,
-			MaxLength:       8,
+			MinLength:       8,
+			MaxLength:       0,
 			AllowWhitespace: false,
 		},
 	}


### PR DESCRIPTION
Defaulting to maximum password lengths of 8 characters is very dangerous, and
authboss uses bcrypt under the hood. Technically, this could be even higher,
though not unbounded (because of HTTP client request size limits, especially
when dealing with password change forms).

Fixes #149