### PR TITLE
Allow user to configure FromName in ab emails

### DIFF
--- a/config.go
+++ b/config.go
@@ -94,6 +94,8 @@ type Config struct {
 
 	// EmailFrom is the email address authboss e-mails come from.
 	EmailFrom string
+	// EmailFromName is the name used in the From: header of authboss emails.
+	EmailFromName string
 	// EmailSubjectPrefix is used to add something to the front of the authboss
 	// email subjects.
 	EmailSubjectPrefix string

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -149,9 +149,10 @@ func (c *Confirm) confirmEmail(ctx *authboss.Context, to, token string) {
 	url := fmt.Sprintf("%s%s?%s=%s", c.RootURL, p, url.QueryEscape(FormValueConfirm), url.QueryEscape(token))
 
 	email := authboss.Email{
-		To:      []string{to},
-		From:    c.EmailFrom,
-		Subject: c.EmailSubjectPrefix + "Confirm New Account",
+		To:       []string{to},
+		From:     c.EmailFrom,
+		FromName: c.EmailFromName,
+		Subject:  c.EmailSubjectPrefix + "Confirm New Account",
 	}
 
 	err := response.Email(ctx.Mailer, email, c.emailHTMLTemplates, tplConfirmHTML, c.emailTextTemplates, tplConfirmText, url)

--- a/recover/recover.go
+++ b/recover/recover.go
@@ -12,9 +12,9 @@ import (
 	"path"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
 	"github.com/volatiletech/authboss"
 	"github.com/volatiletech/authboss/internal/response"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Storage constants
@@ -208,9 +208,10 @@ func (r *Recover) sendRecoverEmail(ctx *authboss.Context, to, encodedToken strin
 	url := fmt.Sprintf("%s%s?%s", r.RootURL, p, query.Encode())
 
 	email := authboss.Email{
-		To:      []string{to},
-		From:    r.EmailFrom,
-		Subject: r.EmailSubjectPrefix + "Password Reset",
+		To:       []string{to},
+		From:     r.EmailFrom,
+		FromName: r.EmailFromName,
+		Subject:  r.EmailSubjectPrefix + "Password Reset",
 	}
 
 	if err := response.Email(ctx.Mailer, email, r.emailHTMLTemplates, tplInitHTMLEmail, r.emailTextTemplates, tplInitTextEmail, url); err != nil {


### PR DESCRIPTION
It's nice to be able to specify a name for the sender, instead of just a plain email address.
Simply specifying EmailFrom in a format like "Name \<name@example.com\>" doesn't work, because this field is passed to smtp.SendMail which expects just a plain email address.