### PR TITLE
use ab.Config.Paths.Mount in /login

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -32,8 +32,8 @@ func (a *Auth) Init(ab *authboss.Authboss) (err error) {
 		return err
 	}
 
-	a.Authboss.Config.Core.Router.Get("/login", a.Authboss.Core.ErrorHandler.Wrap(a.LoginGet))
-	a.Authboss.Config.Core.Router.Post("/login", a.Authboss.Core.ErrorHandler.Wrap(a.LoginPost))
+	a.Authboss.Config.Core.Router.Get(a.Authboss.Config.Paths.Mount+"/login", a.Authboss.Core.ErrorHandler.Wrap(a.LoginGet))
+	a.Authboss.Config.Core.Router.Post(a.Authboss.Config.Paths.Mount+"/login", a.Authboss.Core.ErrorHandler.Wrap(a.LoginPost))
 
 	return nil
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -30,10 +30,10 @@ func TestAuthInit(t *testing.T) {
 		t.Error(err)
 	}
 
-	if err := router.HasGets("/login"); err != nil {
+	if err := router.HasGets("/auth/login"); err != nil {
 		t.Error(err)
 	}
-	if err := router.HasPosts("/login"); err != nil {
+	if err := router.HasPosts("/auth/login"); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
Hello, I need to use ab.Config.Paths.Mount for /login too.

In my usecase I need to use same prefix for login authboss interactions.
```
curl -v -X POST -d '{"username": "nick", "password": "lol"}' http://127.0.0.1:1234/auth2/login
```