### PR TITLE
Fix login get endpoint when no FormValueRedirect is given

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -40,9 +40,9 @@ func (a *Auth) Init(ab *authboss.Authboss) (err error) {
 
 // LoginGet simply displays the login form
 func (a *Auth) LoginGet(w http.ResponseWriter, r *http.Request) error {
-	var data authboss.HTMLData
+	data := authboss.HTMLData{}
 	if redir := r.URL.Query().Get(authboss.FormValueRedirect); len(redir) != 0 {
-		data = authboss.HTMLData{authboss.FormValueRedirect: redir}
+		data[authboss.FormValueRedirect] = redir
 	}
 	return a.Core.Responder.Respond(w, r, http.StatusOK, PageLogin, data)
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -47,7 +47,7 @@ func TestAuthGet(t *testing.T) {
 
 	a := &Auth{ab}
 
-	r := mocks.Request("POST")
+	r := mocks.Request("GET")
 	r.URL.RawQuery = "redir=/redirectpage"
 	if err := a.LoginGet(nil, r); err != nil {
 		t.Error(err)


### PR DESCRIPTION
Currently I'm getting the following error when navigating to the login GET endpoint with no parameters using `defaults.JSONRenderer`:

```
http: panic serving [::1]:61636: assignment to entry in nil map
```
