### PR TITLE
Fix default.Rules lowercase condition

### DIFF
--- a/defaults/rules.go
+++ b/defaults/rules.go
@@ -56,7 +56,7 @@ func (r Rules) Errors(toValidate string) authboss.ErrorList {
 	if upper < r.MinUpper {
 		errs = append(errs, FieldError{r.FieldName, errors.New(r.upperErr())})
 	}
-	if upper < r.MinLower {
+	if lower < r.MinLower {
 		errs = append(errs, FieldError{r.FieldName, errors.New(r.lowerErr())})
 	}
 	if numeric < r.MinNumeric {

--- a/defaults/rules_test.go
+++ b/defaults/rules_test.go
@@ -49,6 +49,11 @@ func TestRules_Errors(t *testing.T) {
 			"email: Must be between 3 and 5 characters",
 		},
 		{
+			Rules{FieldName: "email", MinUpper: 2, MinLower: 1},
+			"AA",
+			"email: Must contain at least 1 lowercase letter",
+		},
+		{
 			Rules{FieldName: "email", MinLetters: 5},
 			"13345",
 			"email: Must contain at least 5 letters",


### PR DESCRIPTION
Fixed a bug in `default.Rules` for the lowercase condition