### PR TITLE
patch bug in OAuth2 module

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -45,7 +45,12 @@ type User struct {
 }
 
 // GetPID from user
-func (u User) GetPID() string { return u.Email }
+func (u User) GetPID() string {
+	if u.IsOAuth2User() {
+		return authboss.MakeOAuth2PID(u.OAuth2Provider, u.OAuth2UID)
+	}
+	return u.Email
+}
 
 // GetEmail from user
 func (u User) GetEmail() string { return u.Email }

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -255,7 +255,7 @@ func (o *OAuth2) End(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Fully log user in
-	authboss.PutSession(w, authboss.SessionKey, authboss.MakeOAuth2PID(provider, user.GetOAuth2UID()))
+	authboss.PutSession(w, authboss.SessionKey, user.GetPID())
 	authboss.DelSession(w, authboss.SessionHalfAuthKey)
 
 	// Create a query string from all the pieces we've received


### PR DESCRIPTION
In the OAuth2 module, the session PID is put like this:

```go
authboss.PutSession(w, authboss.SessionKey, authboss.MakeOAuth2PID(provider, user.GetOAuth2UID()))
```

I don't think it's necessary. Since the `OAuth2User` interface already requires a `GetPID` method, I think we should use that directly and leave it up to the user to create the PID using the Helper function.

This could also cause an issue because `Middleware2` requires `authboss.SessionKey` to be the user PID, and during this process, the`GetPID` method is called.
If the user themselves are not using `authboss.MakeOAuth2PID` to create their PIDs, they will run into a problem because the `End` method in the `OAuth2` modules assumes this **must** be the case.


I've also modified the mocks package to take this into account. So it does not return the email when the Oauth2 module tests ask for the PID.