### PR TITLE
add follow redirect params flag in oauth2 final response

### DIFF
--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -290,9 +290,10 @@ func (o *OAuth2) End(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	ro := authboss.RedirectOptions{
-		Code:         http.StatusTemporaryRedirect,
-		RedirectPath: redirect,
-		Success:      fmt.Sprintf("Logged in successfully with %s.", strings.Title(provider)),
+		Code:             http.StatusTemporaryRedirect,
+		RedirectPath:     redirect,
+		FollowRedirParam: true,
+		Success:          fmt.Sprintf("Logged in successfully with %s.", strings.Title(provider)),
 	}
 	return o.Authboss.Config.Core.Redirector.Redirect(w, r, ro)
 }


### PR DESCRIPTION
Without the follow redir param set to true, it's not so direct to test in the RedirectNonApi method of the redirector if the redir path contains the oauth2 provider authentication url or the user's redirect url typed in the url query.

In the redirect API method, the followRedirectParam field is used to checks the value of redir, in oauth2 it's not set after login.
I just added followRedirOptions = true in the redirect options built at the end of the "End" method after a oAuth2 login. 