### PR TITLE
Feature/configurable hashing and encoding

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"net/http"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/volatiletech/authboss/v3"
 )
 
@@ -77,7 +75,7 @@ func (a *Auth) LoginPost(w http.ResponseWriter, r *http.Request) error {
 	r = r.WithContext(context.WithValue(r.Context(), authboss.CTXKeyUser, pidUser))
 
 	var handled bool
-	err = bcrypt.CompareHashAndPassword([]byte(password), []byte(creds.GetPassword()))
+	err = a.Authboss.Core.Hasher.CompareHashAndPassword(password, creds.GetPassword())
 	if err != nil {
 		handled, err = a.Authboss.Events.FireAfter(authboss.EventAuthFail, w, r)
 		if err != nil {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -91,6 +91,7 @@ func testSetup() *testHarness {
 
 	harness.ab.Config.Core.BodyReader = harness.bodyReader
 	harness.ab.Config.Core.Logger = mocks.Logger{}
+	harness.ab.Config.Core.Hasher = mocks.Hasher{}
 	harness.ab.Config.Core.Responder = harness.responder
 	harness.ab.Config.Core.Redirector = harness.redirector
 	harness.ab.Config.Storage.SessionState = harness.session

--- a/authboss.go
+++ b/authboss.go
@@ -65,12 +65,12 @@ func (a *Authboss) Init(modulesToLoad ...string) error {
 // in sessions for a user requires special mechanisms not currently provided
 // by authboss.
 func (a *Authboss) UpdatePassword(ctx context.Context, user AuthableUser, newPassword string) error {
-	pass, err := bcrypt.GenerateFromPassword([]byte(newPassword), a.Config.Modules.BCryptCost)
+	pass, err := a.Config.Core.Hasher.GenerateHash(newPassword)
 	if err != nil {
 		return err
 	}
 
-	user.PutPassword(string(pass))
+	user.PutPassword(pass)
 
 	storer := a.Config.Storage.Server
 	if err := storer.Save(ctx, user); err != nil {

--- a/authboss.go
+++ b/authboss.go
@@ -89,6 +89,9 @@ func (a *Authboss) UpdatePassword(ctx context.Context, user AuthableUser, newPas
 // Returns nil on success otherwise there will be an error. Simply a helper
 // to do the bcrypt comparison.
 func VerifyPassword(user AuthableUser, password string) error {
+	// TODO: function can be used ONLY if no custom hasher was configured in global ab.config
+	//       function should be either deprecated, or he we should have access to global ab's config
+	//       (also, we can't use defaults.NewBcryptHasher, because it will be cyclic dep)
 	return bcrypt.CompareHashAndPassword([]byte(user.GetPassword()), []byte(password))
 }
 

--- a/authboss_test.go
+++ b/authboss_test.go
@@ -25,6 +25,7 @@ func TestAuthbossUpdatePassword(t *testing.T) {
 
 	ab := New()
 	ab.Config.Storage.Server = storer
+	ab.Config.Core.Hasher = mockHasher{}
 
 	if err := ab.UpdatePassword(context.Background(), user, "hello world"); err != nil {
 		t.Error(err)

--- a/config.go
+++ b/config.go
@@ -239,6 +239,9 @@ type Config struct {
 		// Mailer is the mailer being used to send e-mails out via smtp
 		Mailer Mailer
 
+		// Hasher hashes passwords into hashes
+		Hasher Hasher
+
 		// Logger implies just a few log levels for use, can optionally
 		// also implement the ContextLogger to be able to upgrade to a
 		// request specific logger.

--- a/config.go
+++ b/config.go
@@ -242,6 +242,9 @@ type Config struct {
 		// Hasher hashes passwords into hashes
 		Hasher Hasher
 
+		// CredsGenerator generates credentials (selector+verified+token)
+		CredsGenerator CredsGenerator
+
 		// Logger implies just a few log levels for use, can optionally
 		// also implement the ContextLogger to be able to upgrade to a
 		// request specific logger.

--- a/confirm/confirm.go
+++ b/confirm/confirm.go
@@ -3,12 +3,9 @@ package confirm
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -33,9 +30,6 @@ const (
 	// DataConfirmURL is the name of the e-mail template variable
 	// that gives the url to send to the user for confirmation.
 	DataConfirmURL = "url"
-
-	confirmTokenSize  = 64
-	confirmTokenSplit = confirmTokenSize / 2
 )
 
 func init() {
@@ -128,7 +122,7 @@ func (c *Confirm) StartConfirmationWeb(w http.ResponseWriter, r *http.Request, h
 func (c *Confirm) StartConfirmation(ctx context.Context, user authboss.ConfirmableUser, sendEmail bool) error {
 	logger := c.Authboss.Logger(ctx)
 
-	selector, verifier, token, err := GenerateConfirmCreds()
+	selector, verifier, token, err := c.Authboss.Core.CredsGenerator.GenerateCreds()
 	if err != nil {
 		return err
 	}
@@ -198,13 +192,14 @@ func (c *Confirm) Get(w http.ResponseWriter, r *http.Request) error {
 		return c.invalidToken(w, r)
 	}
 
-	if len(rawToken) != confirmTokenSize {
+	credsGenerator := c.Authboss.Core.CredsGenerator
+
+	if len(rawToken) != credsGenerator.TokenSize() {
 		logger.Infof("invalid confirm token submitted, size was wrong: %d", len(rawToken))
 		return c.invalidToken(w, r)
 	}
 
-	selectorBytes := sha512.Sum512(rawToken[:confirmTokenSplit])
-	verifierBytes := sha512.Sum512(rawToken[confirmTokenSplit:])
+	selectorBytes, verifierBytes := credsGenerator.ParseToken(string(rawToken))
 	selector := base64.StdEncoding.EncodeToString(selectorBytes[:])
 
 	storer := authboss.EnsureCanConfirm(c.Authboss.Config.Storage.Server)
@@ -295,24 +290,4 @@ func Middleware(ab *authboss.Authboss) func(http.Handler) http.Handler {
 			}
 		})
 	}
-}
-
-// GenerateConfirmCreds generates pieces needed for user confirm
-// selector: hash of the first half of a 64 byte value
-// (to be stored in the database and used in SELECT query)
-// verifier: hash of the second half of a 64 byte value
-// (to be stored in database but never used in SELECT query)
-// token: the user-facing base64 encoded selector+verifier
-func GenerateConfirmCreds() (selector, verifier, token string, err error) {
-	rawToken := make([]byte, confirmTokenSize)
-	if _, err = io.ReadFull(rand.Reader, rawToken); err != nil {
-		return "", "", "", err
-	}
-	selectorBytes := sha512.Sum512(rawToken[:confirmTokenSplit])
-	verifierBytes := sha512.Sum512(rawToken[confirmTokenSplit:])
-
-	return base64.StdEncoding.EncodeToString(selectorBytes[:]),
-		base64.StdEncoding.EncodeToString(verifierBytes[:]),
-		base64.URLEncoding.EncodeToString(rawToken),
-		nil
 }

--- a/confirm/confirm_test.go
+++ b/confirm/confirm_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"errors"
+	"github.com/volatiletech/authboss/v3/defaults"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -71,6 +72,7 @@ func testSetup() *testHarness {
 
 	harness.ab.Config.Core.BodyReader = harness.bodyReader
 	harness.ab.Config.Core.Logger = mocks.Logger{}
+	harness.ab.Config.Core.Hasher = defaults.NewBCryptHasher(harness.ab.Modules.BCryptCost)
 	harness.ab.Config.Core.Mailer = harness.mailer
 	harness.ab.Config.Core.Redirector = harness.redirector
 	harness.ab.Config.Core.MailRenderer = harness.renderer

--- a/creds_generator.go
+++ b/creds_generator.go
@@ -1,0 +1,13 @@
+package authboss
+
+type CredsGenerator interface {
+	// GenerateCreds generates pieces needed as credentials
+	// selector: to be stored in the database and used in SELECT query
+	// verifier: to be stored in database but never used in SELECT query
+	// token: the user-facing base64 encoded selector+verifier
+	GenerateCreds() (selector, verifier, token string, err error)
+
+	ParseToken(token string) (selectorBytes, verifierBytes []byte)
+
+	TokenSize() int
+}

--- a/defaults/creds_generator.go
+++ b/defaults/creds_generator.go
@@ -1,0 +1,52 @@
+package defaults
+
+import (
+	"crypto/rand"
+	"crypto/sha512"
+	"encoding/base64"
+	"io"
+)
+
+const (
+	tokenSize  = 64
+	tokenSplit = tokenSize / 2
+)
+
+type Sha512CredsGenerator struct{}
+
+func NewSha512CredsGenerator() *Sha512CredsGenerator {
+	return &Sha512CredsGenerator{}
+}
+
+// GenerateCreds generates pieces needed as credentials
+// selector: hash of the first half of an N byte value
+// (to be stored in the database and used in SELECT query)
+// verifier: hash of the second half of an N byte value
+// (to be stored in database but never used in SELECT query)
+// token: the user-facing base64 encoded selector+verifier
+func (cg *Sha512CredsGenerator) GenerateCreds() (selector, verifier, token string, err error) {
+	rawToken := make([]byte, tokenSize)
+	if _, err = io.ReadFull(rand.Reader, rawToken); err != nil {
+		return "", "", "", err
+	}
+
+	selectorBytes := sha512.Sum512(rawToken[:tokenSplit])
+	verifierBytes := sha512.Sum512(rawToken[tokenSplit:])
+
+	return base64.StdEncoding.EncodeToString(selectorBytes[:]),
+		base64.StdEncoding.EncodeToString(verifierBytes[:]),
+		base64.URLEncoding.EncodeToString(rawToken),
+		nil
+}
+
+func (cg *Sha512CredsGenerator) ParseToken(rawToken string) (selectorBytes, verifierBytes []byte) {
+	selectorBytes64 := sha512.Sum512([]byte(rawToken)[:tokenSplit])
+	selectorBytes = selectorBytes64[:]
+
+	verifierBytes64 := sha512.Sum512([]byte(rawToken)[tokenSplit:])
+	verifierBytes = verifierBytes64[:]
+
+	return
+}
+
+func (cg *Sha512CredsGenerator) TokenSize() int { return tokenSize }

--- a/defaults/creds_generator_test.go
+++ b/defaults/creds_generator_test.go
@@ -1,0 +1,40 @@
+package defaults
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestCredsGenerator(t *testing.T) {
+	t.Parallel()
+
+	credsGenerator := NewSha512CredsGenerator()
+
+	selector, verifier, tokenEncoded, err := credsGenerator.GenerateCreds()
+	if err != nil {
+		t.Error(err)
+	}
+
+	// let's decode the token
+	tokenBytes, err := base64.URLEncoding.DecodeString(tokenEncoded)
+	token := string(tokenBytes)
+
+	if len(token) != credsGenerator.TokenSize() {
+		t.Error("token size is invalid", len(token))
+	}
+
+	selectorBytes, verifierBytes := credsGenerator.ParseToken(token)
+
+	// encode back and verify
+
+	selectorParsed := base64.StdEncoding.EncodeToString(selectorBytes[:])
+	verifierParsed := base64.StdEncoding.EncodeToString(verifierBytes[:])
+
+	if selectorParsed != selector {
+		t.Error("selector generated wrong", selector, selectorParsed)
+	}
+
+	if verifierParsed != verifier {
+		t.Error("verifier generated wrong", verifier, verifierParsed)
+	}
+}

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -25,5 +25,6 @@ func SetCore(config *authboss.Config, readJSON, useUsername bool) {
 	config.Core.Redirector = NewRedirector(config.Core.ViewRenderer, authboss.FormValueRedirect)
 	config.Core.BodyReader = NewHTTPBodyReader(readJSON, useUsername)
 	config.Core.Mailer = NewLogMailer(os.Stdout)
+	config.Core.Hasher = NewBCryptHasher(config.Modules.BCryptCost)
 	config.Core.Logger = logger
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -26,5 +26,6 @@ func SetCore(config *authboss.Config, readJSON, useUsername bool) {
 	config.Core.BodyReader = NewHTTPBodyReader(readJSON, useUsername)
 	config.Core.Mailer = NewLogMailer(os.Stdout)
 	config.Core.Hasher = NewBCryptHasher(config.Modules.BCryptCost)
+	config.Core.CredsGenerator = NewSha512CredsGenerator()
 	config.Core.Logger = logger
 }

--- a/defaults/defaults_test.go
+++ b/defaults/defaults_test.go
@@ -36,4 +36,10 @@ func TestSetCore(t *testing.T) {
 	if config.Core.Logger == nil {
 		t.Error("logger should be set")
 	}
+	if config.Core.Hasher == nil {
+		t.Error("hasher should be set")
+	}
+	if config.Core.CredsGenerator == nil {
+		t.Error("creds-generator should be set")
+	}
 }

--- a/defaults/hasher.go
+++ b/defaults/hasher.go
@@ -1,0 +1,20 @@
+package defaults
+
+import "golang.org/x/crypto/bcrypt"
+
+type BCryptHasher struct {
+	cost int
+}
+
+func NewBCryptHasher(cost int) *BCryptHasher {
+	return &BCryptHasher{cost: cost}
+}
+
+func (h *BCryptHasher) GenerateHash(raw string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(raw), h.cost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}

--- a/defaults/hasher.go
+++ b/defaults/hasher.go
@@ -18,3 +18,7 @@ func (h *BCryptHasher) GenerateHash(raw string) (string, error) {
 
 	return string(hash), nil
 }
+
+func (h *BCryptHasher) CompareHashAndPassword(hashedPassword, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
+}

--- a/defaults/hasher_test.go
+++ b/defaults/hasher_test.go
@@ -1,0 +1,29 @@
+package defaults
+
+import (
+	"golang.org/x/crypto/bcrypt"
+	"strings"
+	"testing"
+)
+
+func TestHasher(t *testing.T) {
+	t.Parallel()
+
+	hasher := NewBCryptHasher(bcrypt.DefaultCost)
+
+	hash, err := hasher.GenerateHash("qwerty")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if hash == "" {
+		t.Error("Result Hash must be not empty")
+
+	}
+	if len(hash) != 60 {
+		t.Error("hash was invalid length", len(hash))
+	}
+	if !strings.HasPrefix(hash, "$2a$10$") {
+		t.Error("hash was wrong", hash)
+	}
+}

--- a/defaults/hasher_test.go
+++ b/defaults/hasher_test.go
@@ -26,4 +26,12 @@ func TestHasher(t *testing.T) {
 	if !strings.HasPrefix(hash, "$2a$10$") {
 		t.Error("hash was wrong", hash)
 	}
+
+	if err := hasher.CompareHashAndPassword(hash, "qwerty"); err != nil {
+		t.Error("compare-hash-and-password for valid password must be ok", err)
+	}
+
+	if err := hasher.CompareHashAndPassword(hash, "qwerty-invalid"); err == nil {
+		t.Error("compare-hash-and-password for invalid password must fail")
+	}
 }

--- a/hasher.go
+++ b/hasher.go
@@ -1,5 +1,6 @@
 package authboss
 
 type Hasher interface {
+	CompareHashAndPassword(string, string) error
 	GenerateHash(s string) (string, error)
 }

--- a/hasher.go
+++ b/hasher.go
@@ -1,0 +1,5 @@
+package authboss
+
+type Hasher interface {
+	GenerateHash(s string) (string, error)
+}

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -3,6 +3,7 @@ package mocks
 
 import (
 	"context"
+	"golang.org/x/crypto/bcrypt"
 	"io"
 	"net/http"
 	"net/url"
@@ -750,4 +751,20 @@ func (e *ErrorHandler) Wrap(handler func(w http.ResponseWriter, r *http.Request)
 			e.Error = err
 		}
 	})
+}
+
+// Hasher is actually just a normal bcrypt hasher
+type Hasher struct{}
+
+func (m Hasher) GenerateHash(s string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(s), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}
+
+func (m Hasher) CompareHashAndPassword(hashedPassword, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
 }

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -3,6 +3,7 @@ package authboss
 import (
 	"context"
 	"encoding/json"
+	"golang.org/x/crypto/bcrypt"
 	"net/http"
 	"time"
 )
@@ -213,3 +214,14 @@ type mockLogger struct{}
 
 func (m mockLogger) Info(s string)  {}
 func (m mockLogger) Error(s string) {}
+
+type mockHasher struct{}
+
+func (m mockHasher) GenerateHash(s string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(s), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}

--- a/mocks_test.go
+++ b/mocks_test.go
@@ -225,3 +225,7 @@ func (m mockHasher) GenerateHash(s string) (string, error) {
 
 	return string(hash), nil
 }
+
+func (m mockHasher) CompareHashAndPassword(hashedPassword, password string) error {
+	return bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
+}

--- a/recover/recover.go
+++ b/recover/recover.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/volatiletech/authboss/v3"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // Constants for templates etc.
@@ -263,12 +262,12 @@ func (r *Recover) EndPost(w http.ResponseWriter, req *http.Request) error {
 		return nil
 	}
 
-	pass, err := bcrypt.GenerateFromPassword([]byte(password), r.Authboss.Config.Modules.BCryptCost)
+	pass, err := r.Authboss.Config.Core.Hasher.GenerateHash(password)
 	if err != nil {
 		return err
 	}
 
-	user.PutPassword(string(pass))
+	user.PutPassword(pass)
 	user.PutRecoverSelector("")             // Don't allow another recovery
 	user.PutRecoverVerifier("")             // Don't allow another recovery
 	user.PutRecoverExpiry(time.Now().UTC()) // Put current time for those DBs that can't handle 0 time

--- a/recover/recover.go
+++ b/recover/recover.go
@@ -3,13 +3,10 @@ package recover
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/sha512"
 	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -33,9 +30,6 @@ const (
 	PageRecoverEnd    = "recover_end"
 
 	recoverInitiateSuccessFlash = "An email has been sent to you with further instructions on how to reset your password."
-
-	recoverTokenSize  = 64
-	recoverTokenSplit = recoverTokenSize / 2
 )
 
 func init() {
@@ -112,7 +106,7 @@ func (r *Recover) StartPost(w http.ResponseWriter, req *http.Request) error {
 		return nil
 	}
 
-	selector, verifier, token, err := GenerateRecoverCreds()
+	selector, verifier, token, err := r.Authboss.Config.Core.CredsGenerator.GenerateCreds()
 	if err != nil {
 		return err
 	}
@@ -219,13 +213,14 @@ func (r *Recover) EndPost(w http.ResponseWriter, req *http.Request) error {
 		return r.invalidToken(PageRecoverEnd, w, req)
 	}
 
-	if len(rawToken) != recoverTokenSize {
+	credsGenerator := r.Authboss.Core.CredsGenerator
+
+	if len(rawToken) != credsGenerator.TokenSize() {
 		logger.Infof("invalid recover token submitted, size was wrong: %d", len(rawToken))
 		return r.invalidToken(PageRecoverEnd, w, req)
 	}
 
-	selectorBytes := sha512.Sum512(rawToken[:recoverTokenSplit])
-	verifierBytes := sha512.Sum512(rawToken[recoverTokenSplit:])
+	selectorBytes, verifierBytes := credsGenerator.ParseToken(string(rawToken))
 	selector := base64.StdEncoding.EncodeToString(selectorBytes[:])
 
 	storer := authboss.EnsureCanRecover(r.Authboss.Config.Storage.Server)
@@ -310,24 +305,4 @@ func (r *Recover) mailURL(token string) string {
 
 	p := path.Join(r.Config.Paths.Mount, "recover/end")
 	return fmt.Sprintf("%s%s?%s", r.Config.Paths.RootURL, p, query.Encode())
-}
-
-// GenerateRecoverCreds generates pieces needed for user recovery
-// selector: hash of the first half of a 64 byte value
-// (to be stored in the database and used in SELECT query)
-// verifier: hash of the second half of a 64 byte value
-// (to be stored in database but never used in SELECT query)
-// token: the user-facing base64 encoded selector+verifier
-func GenerateRecoverCreds() (selector, verifier, token string, err error) {
-	rawToken := make([]byte, recoverTokenSize)
-	if _, err = io.ReadFull(rand.Reader, rawToken); err != nil {
-		return "", "", "", err
-	}
-	selectorBytes := sha512.Sum512(rawToken[:recoverTokenSplit])
-	verifierBytes := sha512.Sum512(rawToken[recoverTokenSplit:])
-
-	return base64.StdEncoding.EncodeToString(selectorBytes[:]),
-		base64.StdEncoding.EncodeToString(verifierBytes[:]),
-		base64.URLEncoding.EncodeToString(rawToken),
-		nil
 }

--- a/recover/recover_test.go
+++ b/recover/recover_test.go
@@ -444,7 +444,7 @@ func TestGenerateRecoverCreds(t *testing.T) {
 
 	selector, verifier, token, err := credsGenerator.GenerateCreds()
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 	recoverTokenSplit := credsGenerator.TokenSize() / 2
 

--- a/recover/recover_test.go
+++ b/recover/recover_test.go
@@ -87,6 +87,7 @@ func testSetup() *testHarness {
 	harness.ab.Config.Core.BodyReader = harness.bodyReader
 	harness.ab.Config.Core.Logger = mocks.Logger{}
 	harness.ab.Config.Core.Hasher = defaults.NewBCryptHasher(harness.ab.Config.Modules.BCryptCost)
+	harness.ab.Config.Core.CredsGenerator = defaults.NewSha512CredsGenerator()
 	harness.ab.Config.Core.Mailer = harness.mailer
 	harness.ab.Config.Core.Redirector = harness.redirector
 	harness.ab.Config.Core.MailRenderer = harness.renderer
@@ -439,10 +440,13 @@ func invalidCheck(t *testing.T, h *testHarness, w *httptest.ResponseRecorder) {
 func TestGenerateRecoverCreds(t *testing.T) {
 	t.Parallel()
 
-	selector, verifier, token, err := GenerateRecoverCreds()
+	credsGenerator := defaults.NewSha512CredsGenerator()
+
+	selector, verifier, token, err := credsGenerator.GenerateCreds()
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
+	recoverTokenSplit := credsGenerator.TokenSize() / 2
 
 	if verifier == selector {
 		t.Error("the verifier and selector should be different")

--- a/recover/recover_test.go
+++ b/recover/recover_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha512"
 	"encoding/base64"
 	"errors"
+	"github.com/volatiletech/authboss/v3/defaults"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -85,6 +86,7 @@ func testSetup() *testHarness {
 
 	harness.ab.Config.Core.BodyReader = harness.bodyReader
 	harness.ab.Config.Core.Logger = mocks.Logger{}
+	harness.ab.Config.Core.Hasher = defaults.NewBCryptHasher(harness.ab.Config.Modules.BCryptCost)
 	harness.ab.Config.Core.Mailer = harness.mailer
 	harness.ab.Config.Core.Redirector = harness.redirector
 	harness.ab.Config.Core.MailRenderer = harness.renderer

--- a/register/register.go
+++ b/register/register.go
@@ -9,7 +9,6 @@ import (
 	"github.com/friendsofgo/errors"
 
 	"github.com/volatiletech/authboss/v3"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // Pages
@@ -92,13 +91,13 @@ func (r *Register) Post(w http.ResponseWriter, req *http.Request) error {
 	storer := authboss.EnsureCanCreate(r.Config.Storage.Server)
 	user := authboss.MustBeAuthable(storer.New(req.Context()))
 
-	pass, err := bcrypt.GenerateFromPassword([]byte(password), r.Config.Modules.BCryptCost)
+	pass, err := r.Authboss.Config.Core.Hasher.GenerateHash(password)
 	if err != nil {
 		return err
 	}
 
 	user.PutPID(pid)
-	user.PutPassword(string(pass))
+	user.PutPassword(pass)
 
 	if arbUser, ok := user.(authboss.ArbitraryUser); ok && arbitrary != nil {
 		arbUser.PutArbitrary(arbitrary)

--- a/register/register_test.go
+++ b/register/register_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/authboss/v3"
+	"github.com/volatiletech/authboss/v3/defaults"
 	"github.com/volatiletech/authboss/v3/mocks"
 )
 
@@ -88,6 +89,7 @@ func testSetup() *testHarness {
 
 	harness.ab.Config.Core.BodyReader = harness.bodyReader
 	harness.ab.Config.Core.Logger = mocks.Logger{}
+	harness.ab.Config.Core.Hasher = defaults.NewBCryptHasher(harness.ab.Modules.BCryptCost)
 	harness.ab.Config.Core.Responder = harness.responder
 	harness.ab.Config.Core.Redirector = harness.redirector
 	harness.ab.Config.Storage.SessionState = harness.session

--- a/register/register_test.go
+++ b/register/register_test.go
@@ -5,8 +5,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"golang.org/x/crypto/bcrypt"
-
 	"github.com/friendsofgo/errors"
 	"github.com/volatiletech/authboss/v3"
 	"github.com/volatiletech/authboss/v3/defaults"
@@ -132,7 +130,7 @@ func TestRegisterPostSuccess(t *testing.T) {
 		if !ok {
 			t.Error("user was not persisted in the DB")
 		}
-		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("hello world")); err != nil {
+		if err := h.ab.Config.Core.Hasher.CompareHashAndPassword(user.Password, "hello world"); err != nil {
 			t.Error("password was not properly encrypted:", err)
 		}
 
@@ -175,7 +173,7 @@ func TestRegisterPostSuccess(t *testing.T) {
 		if !ok {
 			t.Error("user was not persisted in the DB")
 		}
-		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte("hello world")); err != nil {
+		if err := h.ab.Config.Core.Hasher.CompareHashAndPassword(user.Password, "hello world"); err != nil {
 			t.Error("password was not properly encrypted:", err)
 		}
 


### PR DESCRIPTION
### Problem

#### Password hashing :hash:
Password hashing process is hard-coded and can't be modified in any kind. There are cases where we do need control on how password is hashed:
+ Current flow is that user is fetched and then password is checked. But we don't want DB to return user at all, until we are 100% password is right. So we need to first, hash password and query by matching hashed passwords.
+ Other simple example is that application may have some requirements on hashing algorithms. 

#### Confirming/Recovering tokens :envelope: 
Reasons for unhardcoding this part:
+ For easier and better testing we need ability to mock token, selector, verifier
+ We need tokens to look shorter/prettier for some reason

#### Problematic part :red_circle: :
`authboss.go` has a public helper function `VerifyPassword`, that now works only if we use default `Hasher`. a todo item is left there in comments, explaining the issue

Fixes #319, #288 